### PR TITLE
Memory check for LoginState.

### DIFF
--- a/World/Updates/Rel21/21000_10_Warden_Mem_Check_LoginState
+++ b/World/Updates/Rel21/21000_10_Warden_Mem_Check_LoginState
@@ -1,0 +1,1 @@
+INSERT INTO `warden_checks` VALUES ('770', '243', '', '', '11801720', '4', '636861727365', 'LoginState');


### PR DESCRIPTION
LoginState is executed when you begin logging into the server. Checking LoginState is probably useful for any keyloggers/malware hooking client memory for data.
